### PR TITLE
reading the file as binary

### DIFF
--- a/smc/mw/tool.py
+++ b/smc/mw/tool.py
@@ -70,7 +70,7 @@ def process(input=None, output=None, start=None, stages=None,
         input = sys.stdin.read()
     else:
         filename = input
-        with open(input, "r") as fh:
+        with open(input, "rb") as fh:
             input = fh.read().decode("UTF-8")
 
     headings = None


### PR DESCRIPTION
Python3 compatibility by reading file as binary and then decoding it in UTF8

```
>>> with open('test.txt', 'r') as fid:
...     fid.read().decode('utf-8')
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
AttributeError: 'str' object has no attribute 'decode'
```

```
>>> with open('test.txt', 'rb') as fid:
...     fid.read().decode('utf-8')
...
''
```
