### PR TITLE
rm html attribute's redundant &quot

### DIFF
--- a/smc/mw/semantics.py
+++ b/smc/mw/semantics.py
@@ -1055,6 +1055,10 @@ class mwSemantics(object):
         for attrib in attribs:
             name = attrib.name.lower()
             value = attrib.value
+            if value.startswith("'") or value.startswith('"'):
+                value = value[1:]
+            if value.endswith("'") or value.endswith('"'):
+                value = value[:-1]
             if name.startswith("data-"):
                 pass
             elif name not in whitelist:


### PR DESCRIPTION
To parse string like 
  
         {| class=&quot;infobox&quot; style=&quot;width:30em&quot;

will produce 
        
    <table class="&quot;infobox&quot;" style="&quot;width:30em&quot;">

this patch try to rm those redundant &quot:

    <table class="infobox" style="width:30em">
